### PR TITLE
RegisterAttendance UI, local persistence and ViewAttendance viewer.

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -16,9 +16,11 @@
 				"axios": "^1.12.2",
 				"framer-motion": "^12.23.24",
 				"react": "^19.1.1",
+				"react-clock": "^6.0.0",
 				"react-datepicker": "^8.8.0",
 				"react-dom": "^19.1.1",
-				"react-router-dom": "^7.9.4"
+				"react-router-dom": "^7.9.4",
+				"react-time-picker": "^8.0.2"
 			},
 			"devDependencies": {
 				"@eslint/js": "^9.36.0",
@@ -2452,6 +2454,15 @@
 				"vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
 			}
 		},
+		"node_modules/@wojtekmaj/date-utils": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@wojtekmaj/date-utils/-/date-utils-2.0.2.tgz",
+			"integrity": "sha512-Do66mSlSNifFFuo3l9gNKfRMSFi26CRuQMsDJuuKO/ekrDWuTTtE4ZQxoFCUOG+NgxnpSeBq/k5TY8ZseEzLpA==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/wojtekmaj/date-utils?sponsor=1"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -3160,6 +3171,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/detect-element-overflow": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/detect-element-overflow/-/detect-element-overflow-2.0.0.tgz",
+			"integrity": "sha512-DETEHRGdIdQowMR1Fb5hG4WXUJhlLId/IRQgAi5GVqCnHwnb0SKf9V/teyEVDX0+iClPeOPiNvlE6fSiECz65w==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/wojtekmaj/detect-element-overflow?sponsor=1"
 			}
 		},
 		"node_modules/detect-libc": {
@@ -4159,6 +4179,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/get-user-locale": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/get-user-locale/-/get-user-locale-3.0.0.tgz",
+			"integrity": "sha512-iJfHSmdYV39UUBw7Jq6GJzeJxUr4U+S03qdhVuDsR9gCEnfbqLy9gYDJFBJQL1riqolFUKQvx36mEkp2iGgJ3g==",
+			"license": "MIT",
+			"dependencies": {
+				"memoize": "^10.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/wojtekmaj/get-user-locale?sponsor=1"
 			}
 		},
 		"node_modules/glob-parent": {
@@ -5261,6 +5293,15 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/make-event-props": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/make-event-props/-/make-event-props-2.0.0.tgz",
+			"integrity": "sha512-G/hncXrl4Qt7mauJEXSg3AcdYzmpkIITTNl5I+rH9sog5Yw0kK6vseJjCaPfOXqOqQuPUP89Rkhfz5kPS8ijtw==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/wojtekmaj/make-event-props?sponsor=1"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -5268,6 +5309,21 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/memoize": {
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/memoize/-/memoize-10.2.0.tgz",
+			"integrity": "sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==",
+			"license": "MIT",
+			"dependencies": {
+				"mimic-function": "^5.0.1"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/memoize?sponsor=1"
 			}
 		},
 		"node_modules/merge2": {
@@ -5313,6 +5369,18 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mimic-function": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/minimatch": {
@@ -5787,6 +5855,30 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/react-clock": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/react-clock/-/react-clock-6.0.0.tgz",
+			"integrity": "sha512-qYYrCT9HwDmj5Y2jFGPLc0ktQAZnm+1h2e429/8KBic69PuP1Cp2u0U8k5m3G8A09cOmikQFQitnX6STeGmTpA==",
+			"license": "MIT",
+			"dependencies": {
+				"@wojtekmaj/date-utils": "^2.0.2",
+				"clsx": "^2.0.0",
+				"get-user-locale": "^3.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/wojtekmaj/react-clock?sponsor=1"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/react-datepicker": {
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.8.0.tgz",
@@ -5812,6 +5904,29 @@
 			},
 			"peerDependencies": {
 				"react": "^19.2.0"
+			}
+		},
+		"node_modules/react-fit": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/react-fit/-/react-fit-3.0.0.tgz",
+			"integrity": "sha512-3jrm0k4TZS7n6fZXgCu5k8ARx5w+YbrzpcFMop/iScOjnA22xQVjrVOOJD8YyqRM1j0focbRBrBEJXyydzF/Iw==",
+			"license": "MIT",
+			"dependencies": {
+				"detect-element-overflow": "^2.0.0",
+				"warning": "^4.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/wojtekmaj/react-fit?sponsor=1"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-is": {
@@ -5866,6 +5981,34 @@
 			"peerDependencies": {
 				"react": ">=18",
 				"react-dom": ">=18"
+			}
+		},
+		"node_modules/react-time-picker": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/react-time-picker/-/react-time-picker-8.0.2.tgz",
+			"integrity": "sha512-qT0MDiPy9rFM60QrNNfZ5F9nwDBW1E9DrBtslpM46UPP/RReaWDJrGlvHVH6CjtWHUeJi5sLk1vB+dzLS8ZvnA==",
+			"license": "MIT",
+			"dependencies": {
+				"@wojtekmaj/date-utils": "^2.0.2",
+				"clsx": "^2.0.0",
+				"get-user-locale": "^3.0.0",
+				"make-event-props": "^2.0.0",
+				"react-clock": "^6.0.0",
+				"react-fit": "^3.0.0",
+				"update-input-width": "^1.4.0"
+			},
+			"funding": {
+				"url": "https://github.com/wojtekmaj/react-time-picker?sponsor=1"
+			},
+			"peerDependencies": {
+				"@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/react-transition-group": {
@@ -6720,6 +6863,15 @@
 				"browserslist": ">= 4.21.0"
 			}
 		},
+		"node_modules/update-input-width": {
+			"version": "1.4.2",
+			"resolved": "https://registry.npmjs.org/update-input-width/-/update-input-width-1.4.2.tgz",
+			"integrity": "sha512-/p0XLhrQQQ4bMWD7bL9duYObwYCO1qGr8R19xcMmoMSmXuQ7/1//veUnCObQ7/iW6E2pGS6rFkS4TfH4ur7e/g==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/wojtekmaj/update-input-width?sponsor=1"
+			}
+		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6831,6 +6983,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/warning": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+			"license": "MIT",
+			"dependencies": {
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"node_modules/which": {

--- a/client/package.json
+++ b/client/package.json
@@ -18,9 +18,11 @@
 		"axios": "^1.12.2",
 		"framer-motion": "^12.23.24",
 		"react": "^19.1.1",
+		"react-clock": "^6.0.0",
 		"react-datepicker": "^8.8.0",
 		"react-dom": "^19.1.1",
-		"react-router-dom": "^7.9.4"
+		"react-router-dom": "^7.9.4",
+		"react-time-picker": "^8.0.2"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.36.0",

--- a/client/src/pages/InternalUsersPage/children/RegisterAttendance.tsx
+++ b/client/src/pages/InternalUsersPage/children/RegisterAttendance.tsx
@@ -1,10 +1,512 @@
-import React from "react";
+import React, {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react";
+import DatePicker from "react-datepicker";
+import "react-datepicker/dist/react-datepicker.css";
+import PageTransition from "../../../components/PageTransition";
+
+type Canine = {
+	id: number | string;
+	name: string;
+	photo?: string | null;
+};
+
+type AttendanceRecord = {
+	id: string;
+	canineId: number | string;
+	canineName: string;
+	date: string;
+	entryTime?: string | null;
+	status: "on_time" | "late" | "absent";
+	exitTime?: string | null;
+	earlyDepartureReason?: string | null;
+};
+
+const MOCK_CANINES: Canine[] = [
+	{ id: 11, name: "Toby" },
+	{ id: 12, name: "Luna" },
+	{ id: 13, name: "Koko" },
+	{ id: 14, name: "Toby Jr." },
+	{ id: 15, name: "Milo" },
+];
+
+const ATT_KEY = "mockAttendances_v1";
+
+function toLocalISO(d: Date) {
+	const y = d.getFullYear();
+	const m = String(d.getMonth() + 1).padStart(2, "0");
+	const day = String(d.getDate()).padStart(2, "0");
+	return `${y}-${m}-${day}`;
+}
+
+function nowHHMM() {
+	const n = new Date();
+	return `${String(n.getHours()).padStart(2, "0")}:${String(n.getMinutes()).padStart(2, "0")}`;
+}
 
 export default function RegisterAttendance() {
+	const today = new Date();
+	const [date, setDate] = useState<Date>(today);
+	const [canines, setCanines] = useState<Canine[]>([]);
+	const [loadingCanines, setLoadingCanines] = useState(false);
+	const [records, setRecords] = useState<AttendanceRecord[]>([]);
+	const datePickerRef = useRef<HTMLInputElement | null>(null);
+
+	const isoDate = useMemo(() => toLocalISO(date), [date]);
+
+	// safe storage helpers
+	const loadAllRecords = useCallback((): AttendanceRecord[] => {
+		try {
+			const raw = localStorage.getItem(ATT_KEY);
+			if (!raw) return [];
+			const parsed = JSON.parse(raw);
+			if (!Array.isArray(parsed)) return [];
+			return parsed.filter(
+				(p) => p && typeof p === "object",
+			) as AttendanceRecord[];
+		} catch {
+			return [];
+		}
+	}, []);
+
+	const saveAllRecords = useCallback((arr: AttendanceRecord[]) => {
+		try {
+			localStorage.setItem(ATT_KEY, JSON.stringify(arr));
+		} catch (err) {
+			console.error("Failed saving attendance records", err);
+		}
+	}, []);
+
+	const loadCanines = useCallback(async () => {
+		setLoadingCanines(true);
+		try {
+			const res = await fetch("/api/canines/");
+			if (res.ok) {
+				const data = await res.json();
+				if (Array.isArray(data)) {
+					const mapped = data.map((c: Record<string, unknown>) => ({
+						id: (c.id ?? c.pk) as number | string,
+						name: (c.name ?? c.nickname ?? c.title) as string,
+						photo: (c.photo as string | undefined) ?? null,
+					}));
+					setCanines(mapped);
+					return;
+				}
+			}
+		} catch {
+			// ignore, fallback below
+		} finally {
+			setLoadingCanines(false);
+		}
+		setCanines(MOCK_CANINES);
+	}, []);
+
+	const loadRecordsForDate = useCallback(() => {
+		const all = loadAllRecords();
+		const filtered = all.filter((r) => r.date === isoDate);
+		setRecords(filtered);
+	}, [isoDate, loadAllRecords]);
+
+	useEffect(() => {
+		void loadCanines();
+	}, [loadCanines]);
+
+	useEffect(() => {
+		loadRecordsForDate();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isoDate]);
+
+	const makeId = (dateStr: string, canineId: number | string) =>
+		`${dateStr}::${String(canineId)}`;
+
+	const upsertRecord = useCallback(
+		(rec: AttendanceRecord) => {
+			const all = loadAllRecords();
+			const others = all.filter((r) => r.id !== rec.id);
+			others.unshift(rec);
+			saveAllRecords(others);
+			if (rec.date === isoDate) {
+				setRecords((prev) => {
+					const without = prev.filter((p) => p.id !== rec.id);
+					return [rec, ...without];
+				});
+			}
+		},
+		[isoDate, loadAllRecords, saveAllRecords],
+	);
+
+	const clearRecordFor = useCallback(
+		(dateStr: string, canineId: number | string) => {
+			const id = makeId(dateStr, canineId);
+			const all = loadAllRecords();
+			const filtered = all.filter((r) => r.id !== id);
+			saveAllRecords(filtered);
+			if (dateStr === isoDate) {
+				setRecords((prev) => prev.filter((r) => r.id !== id));
+			}
+		},
+		[isoDate, loadAllRecords, saveAllRecords],
+	);
+
+	function handleSetStatus(c: Canine, status: AttendanceRecord["status"]) {
+		const id = makeId(isoDate, c.id);
+		const existing = loadAllRecords().find((r) => r.id === id);
+		const rec: AttendanceRecord = existing
+			? {
+					...existing,
+					status,
+					date: isoDate,
+					canineName: c.name,
+					canineId: c.id,
+				}
+			: {
+					id,
+					canineId: c.id,
+					canineName: c.name,
+					date: isoDate,
+					entryTime: null,
+					status,
+					exitTime: null,
+					earlyDepartureReason: null,
+				};
+		upsertRecord(rec);
+	}
+
+	function handleSetEntryTime(c: Canine, t: string | null) {
+		const id = makeId(isoDate, c.id);
+		const existing = loadAllRecords().find((r) => r.id === id);
+		const rec: AttendanceRecord = existing
+			? { ...existing, entryTime: t || null }
+			: {
+					id,
+					canineId: c.id,
+					canineName: c.name,
+					date: isoDate,
+					entryTime: t || null,
+					status: "on_time",
+					exitTime: null,
+					earlyDepartureReason: null,
+				};
+		upsertRecord(rec);
+	}
+
+	function handleSetReason(c: Canine, reason: string) {
+		const id = makeId(isoDate, c.id);
+		const existing = loadAllRecords().find((r) => r.id === id);
+		const rec: AttendanceRecord = existing
+			? { ...existing, earlyDepartureReason: reason || null }
+			: {
+					id,
+					canineId: c.id,
+					canineName: c.name,
+					date: isoDate,
+					entryTime: null,
+					status: "on_time",
+					exitTime: null,
+					earlyDepartureReason: reason || null,
+				};
+		upsertRecord(rec);
+	}
+
+	function handleClear(c: Canine) {
+		if (!confirm("Eliminar registro de este perro para la fecha?")) return;
+		clearRecordFor(isoDate, c.id);
+	}
+
+	function setNowTimeFor(c: Canine) {
+		handleSetEntryTime(c, nowHHMM());
+	}
+
+	const cardStyle: React.CSSProperties = {
+		display: "flex",
+		flexDirection: "column",
+		gap: 16,
+		minHeight: "calc(100vh - 64px)",
+		width: "calc(100% - 64px)",
+		maxWidth: "none",
+		margin: "24px auto",
+	};
+
 	return (
-		<div className="h-full w-full rounded-lg bg-white border border-dashed border-gray-200 p-6">
-			<h2 className="text-lg font-montserrat">Registrar asistencia</h2>
-			<p className="text-gray-500">Registrar asistencia placeholder.</p>
-		</div>
+		<PageTransition>
+			<div className="form-card font-montserrat" style={cardStyle}>
+				<div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+					<div
+						style={{
+							display: "flex",
+							alignItems: "center",
+							gap: 12,
+							flex: "1 1 auto",
+						}}
+					>
+						<div style={{ display: "flex", flexDirection: "column" }}>
+							<label className="form-label" style={{ marginBottom: 6 }}>
+								Fecha
+							</label>
+							<DatePicker
+								ref={datePickerRef}
+								selected={date}
+								onChange={(d: Date) => setDate(d)}
+								dateFormat="dd/MM/yyyy"
+								className="input-primary input-lg input-with-left-icon"
+								calendarClassName="custom-datepicker"
+								maxDate={new Date()}
+								showYearDropdown
+								scrollableYearDropdown
+								yearDropdownItemNumber={100}
+							/>
+						</div>
+
+						<div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
+							<button
+								className="btn-ghost action-btn"
+								onClick={() => loadRecordsForDate()}
+							>
+								Actualizar
+							</button>
+							<button
+								className="btn-ghost action-btn"
+								onClick={() => {
+									if (!confirm(`Eliminar todos los registros de ${isoDate}?`))
+										return;
+									const all = loadAllRecords().filter(
+										(r) => r.date !== isoDate,
+									);
+									saveAllRecords(all);
+									loadRecordsForDate();
+								}}
+							>
+								Limpiar fecha
+							</button>
+						</div>
+					</div>
+				</div>
+
+				<div
+					style={{
+						flex: 1,
+						minHeight: 0,
+						display: "flex",
+						flexDirection: "column",
+					}}
+				>
+					<header
+						style={{
+							display: "flex",
+							justifyContent: "space-between",
+							alignItems: "center",
+							marginBottom: 8,
+						}}
+					>
+						<div>
+							<h3 style={{ margin: 0, fontSize: 16 }}>Perros registrados</h3>
+							<div style={{ color: "var(--muted-color)", fontSize: 13 }}>
+								{loadingCanines ? "Cargando..." : `${canines.length} perros`}
+							</div>
+						</div>
+						<div style={{ color: "var(--muted-color)", fontSize: 13 }}>
+							{records.length} marcados — {isoDate}
+						</div>
+					</header>
+
+					<div
+						className="manage-table-container"
+						style={{ flex: 1, minHeight: 0 }}
+					>
+						<table
+							className="manage-table"
+							style={{
+								width: "100%",
+								borderCollapse: "separate",
+								borderSpacing: 0,
+							}}
+						>
+							<thead>
+								<tr>
+									<th style={{ width: 56 }}></th>
+									<th>Perro</th>
+									<th style={{ width: 240 }}>Estado</th>
+									<th style={{ width: 320 }}>Llegada</th>
+									<th style={{ width: 240 }}>Motivo</th>
+									<th style={{ width: 80 }}></th>
+								</tr>
+							</thead>
+							<tbody>
+								{canines.map((c) => {
+									const rec = records.find(
+										(r) => String(r.canineId) === String(c.id),
+									);
+									const currentStatus = rec?.status ?? "on_time";
+									return (
+										<tr key={c.id}>
+											<td style={{ padding: 12 }}>
+												<div
+													style={{
+														width: 44,
+														height: 44,
+														borderRadius: 8,
+														overflow: "hidden",
+														background: "#F3F4F6",
+														display: "flex",
+														alignItems: "center",
+														justifyContent: "center",
+													}}
+												>
+													<span style={{ color: "#6B7280", fontWeight: 700 }}>
+														{String(c.name || "—")
+															.charAt(0)
+															.toUpperCase()}
+													</span>
+												</div>
+											</td>
+											<td
+												style={{
+													padding: "12px 16px",
+													fontWeight: 700,
+													color: "var(--text-color)",
+												}}
+											>
+												{c.name}
+												<div
+													style={{
+														fontSize: 12,
+														color: "var(--muted-color)",
+														fontWeight: 500,
+													}}
+												>
+													{isoDate}
+												</div>
+											</td>
+
+											<td style={{ padding: "12px 16px" }}>
+												<div style={{ display: "flex", gap: 8 }}>
+													<button
+														type="button"
+														className={
+															currentStatus === "on_time"
+																? "btn-success btn-sm"
+																: "btn-ghost btn-sm"
+														}
+														onClick={() => handleSetStatus(c, "on_time")}
+													>
+														A tiempo
+													</button>
+													<button
+														type="button"
+														className={
+															currentStatus === "late"
+																? "btn-warning btn-sm"
+																: "btn-ghost btn-sm"
+														}
+														onClick={() => handleSetStatus(c, "late")}
+													>
+														Tarde
+													</button>
+													<button
+														type="button"
+														className={
+															currentStatus === "absent"
+																? "btn-danger btn-sm"
+																: "btn-ghost btn-sm"
+														}
+														onClick={() => handleSetStatus(c, "absent")}
+													>
+														Ausente
+													</button>
+												</div>
+											</td>
+
+											<td
+												style={{
+													padding: "12px 16px",
+													display: "flex",
+													gap: 8,
+													alignItems: "center",
+												}}
+											>
+												<input
+													type="time"
+													className="input-primary"
+													value={rec?.entryTime ?? ""}
+													onChange={(e) =>
+														handleSetEntryTime(c, e.target.value || null)
+													}
+													step={60}
+													style={{ minWidth: 120, borderRadius: 10 }}
+												/>
+												<button
+													type="button"
+													className="btn-small"
+													onClick={() => setNowTimeFor(c)}
+													title="Set now"
+												>
+													🕒
+												</button>
+											</td>
+
+											<td
+												style={{
+													padding: "12px 16px",
+													color: "var(--muted-color)",
+												}}
+											>
+												<input
+													className="input-primary reason-input"
+													placeholder="Motivo (opcional)"
+													value={rec?.earlyDepartureReason ?? ""}
+													onChange={(e) => handleSetReason(c, e.target.value)}
+													onBlur={(e) => handleSetReason(c, e.target.value)}
+												/>
+											</td>
+
+											<td style={{ padding: "12px 16px", textAlign: "right" }}>
+												{rec ? (
+													<button
+														className="icon-btn delete-btn"
+														onClick={() => handleClear(c)}
+														title="Eliminar"
+														aria-label={`Eliminar registro ${c.name}`}
+													>
+														🗑
+													</button>
+												) : (
+													<span
+														style={{
+															color: "var(--muted-color)",
+															fontSize: 13,
+														}}
+													>
+														—
+													</span>
+												)}
+											</td>
+										</tr>
+									);
+								})}
+
+								{canines.length === 0 && (
+									<tr>
+										<td
+											colSpan={6}
+											style={{
+												padding: 18,
+												textAlign: "center",
+												color: "var(--muted-color)",
+											}}
+										>
+											No hay perros registrados.
+										</td>
+									</tr>
+								)}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</div>
+		</PageTransition>
 	);
 }

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -437,42 +437,70 @@ input[type="checkbox"].checkbox-primary:focus {
 	background: rgba(16, 24, 40, 0.02);
 }
 
-.btn-small {
-	background: rgba(17, 24, 39, 0.06);
-	color: var(--text-color);
-	border-radius: 10px;
+/* Small / state buttons */
+.btn-sm {
 	padding: 6px 10px;
-	font-size: 0.88rem;
-	border: 1px solid rgba(17, 24, 39, 0.05);
-	cursor: pointer;
-}
-
-/* icon buttons used in table rows */
-.icon-btn {
+	font-size: 0.92rem;
+	border-radius: 10px;
+	font-weight: 700;
+	min-height: 40px;
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 32px;
-	height: 32px;
+}
+
+/* Success (on time) */
+.btn-success {
+	background: rgba(16, 185, 129, 0.12);
+	color: #065f46;
+	border: 1px solid rgba(16, 185, 129, 0.14);
+}
+.btn-success:hover {
+	background: rgba(16, 185, 129, 0.16);
+}
+
+/* Warning (late) - use amber solid to match UI emphasis */
+.btn-warning {
+	background: var(--amber-400);
+	color: var(--primary-contrast);
+	border: none;
+}
+.btn-warning:hover {
+	filter: brightness(0.95);
+}
+
+/* Danger (absent) */
+.btn-danger {
+	background: rgba(239, 68, 68, 0.1);
+	color: #991b1b;
+	border: 1px solid rgba(239, 68, 68, 0.12);
+}
+.btn-danger:hover {
+	background: rgba(239, 68, 68, 0.14);
+}
+
+/* Small neutral button used for "Now" */
+.btn-small {
+	background: rgba(17, 24, 39, 0.04);
+	color: var(--text-color);
+	padding: 6px 8px;
 	border-radius: 8px;
-	border: 1px solid rgba(17, 24, 39, 0.06);
-	background: rgba(17, 24, 39, 0.02);
+	font-size: 0.85rem;
+	border: 1px solid rgba(17, 24, 39, 0.04);
+}
+
+/* Ensure btn-ghost btn-sm looks compact */
+.btn-ghost.btn-sm {
+	padding: 6px 10px;
+	background: transparent;
+	border: 1px solid rgba(17, 24, 39, 0.04);
 	color: var(--muted-color);
-	cursor: pointer;
-	padding: 0;
-	margin-left: 6px;
-	transition:
-		background 0.12s,
-		transform 0.06s;
 }
-.icon-btn:hover {
-	background: rgba(17, 24, 39, 0.06);
-	transform: translateY(-1px);
-}
-.icon-btn.delete {
-	background: rgba(239, 68, 68, 0.03);
-	border-color: rgba(239, 68, 68, 0.08);
-	color: #b91c1c;
+
+/* keep focus outlines consistent */
+button:focus {
+	outline: none;
+	box-shadow: 0 6px 20px rgba(245, 158, 11, 0.08);
 }
 
 /* ----------------------------
@@ -487,6 +515,7 @@ input[type="checkbox"].checkbox-primary:focus {
 	margin: 0 auto;
 	box-shadow: 0 6px 22px rgba(16, 24, 40, 0.06);
 	position: relative;
+	overflow: visible; /* allow react-time-picker clock to render above */
 }
 
 .form-header {
@@ -1207,6 +1236,152 @@ input:focus {
 	background: rgba(245, 158, 11, 0.12);
 	color: var(--text-color);
 	font-weight: 700;
+}
+
+/* make card allow popovers without clipping */
+.form-card {
+	/* keep previous rules */
+	overflow: visible; /* allow react-time-picker clock to render above */
+}
+
+/* container around the table: allow horiz scroll if needed but keep vertical scrolling */
+.manage-table-container {
+	overflow-y: auto;
+	overflow-x: auto;
+	min-height: 0;
+}
+
+/* react-time-picker popover / clock adjustments */
+.react-time-picker__wrapper {
+	position: relative;
+	z-index: 1;
+}
+.react-time-picker__clock {
+	position: absolute !important;
+	top: calc(100% + 8px) !important;
+	left: 0 !important;
+	z-index: 9999 !important;
+	background: #fff !important;
+	border: 1px solid rgba(16, 24, 40, 0.06) !important;
+	border-radius: 10px !important;
+	box-shadow: 0 8px 30px rgba(15, 23, 42, 0.08) !important;
+	width: 260px !important;
+	height: 260px !important;
+}
+
+/* Clock inner styling to ensure visibility */
+.react-clock {
+	width: 100% !important;
+	height: 100% !important;
+}
+
+/* action-btn: make actualizar/limpiar look consistent */
+.btn-ghost.action-btn {
+	min-width: 124px;
+	padding: 0.6rem 0.9rem;
+	border-radius: 0.75rem;
+	font-weight: 700;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+}
+
+/* icon button (delete) */
+.icon-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 40px;
+	height: 40px;
+	border-radius: 8px;
+	border: 1px solid rgba(17, 24, 39, 0.04);
+	background: rgba(17, 24, 39, 0.04);
+	color: var(--muted-color);
+	cursor: pointer;
+}
+.icon-btn:hover {
+	transform: translateY(-2px);
+	box-shadow: 0 6px 20px rgba(16, 24, 40, 0.06);
+}
+
+/* softer delete style */
+.delete-btn {
+	background: rgba(239, 68, 68, 0.06);
+	border: 1px solid rgba(239, 68, 68, 0.08);
+	color: #991b1b;
+}
+.delete-btn:hover {
+	background: rgba(239, 68, 68, 0.1);
+}
+
+/* Reason input keep short to avoid extra horizontal width */
+.reason-input {
+	width: 220px;
+	max-width: 220px;
+}
+
+/* ensure time-picker uses Montserrat */
+.time-picker,
+.time-picker * {
+	font-family:
+		"Montserrat",
+		system-ui,
+		-apple-system,
+		"Segoe UI",
+		Roboto,
+		Arial !important;
+}
+
+/* Time modal overlay (large, centered) */
+.time-modal-overlay {
+	position: fixed;
+	inset: 0;
+	background: rgba(15, 23, 42, 0.36);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 99999;
+	padding: 20px;
+}
+
+.time-modal-card {
+	background: #fff;
+	border-radius: 12px;
+	padding: 20px;
+	min-width: 360px;
+	max-width: 720px;
+	width: 96%;
+	box-shadow: 0 18px 60px rgba(15, 23, 42, 0.18);
+}
+
+/* expand the main attendance card more aggressively */
+.form-card {
+	/* override values for large workspace */
+	max-width: none;
+	width: calc(100% - 64px);
+	margin: 24px auto;
+}
+
+/* Ensure table container handles overflow without clipping modal */
+.manage-table-container {
+	overflow-y: auto;
+	overflow-x: auto;
+	min-height: 0;
+	position: relative;
+}
+
+/* ensure modal inputs use Montserrat */
+.time-modal-card .input-primary,
+.time-modal-card .btn-primary,
+.time-modal-card .btn-ghost {
+	font-family:
+		"Montserrat",
+		system-ui,
+		-apple-system,
+		"Segoe UI",
+		Roboto,
+		"Helvetica Neue",
+		Arial !important;
 }
 
 /* ----------------------------


### PR DESCRIPTION
- Introduce RegisterAttendance: full-height attendance register with DatePicker, per-dog 3-state controls (on_time / late / absent) styled (green/yellow/red), inline editable time input with quick "now" action, compact reason field, per-record delete and clear-date actions. Records persisted to localStorage under ATT_KEY and only created/updated on explicit user actions.
- Add ViewAttendance: read-only attendance viewer using DatePicker, API fetch with mock fallback, single-line status badges and PageTransition wrapper for consistent navigation.
- UX & layout: stretched attendance card to better use viewport, shortened reason input to avoid horizontal scroll, improved table container overflow handling and action button styling.
- Styling & housekeeping: new/updated CSS for state buttons, small buttons, delete icon, datepicker theming and overflow fixes. Minor lint/type tidy-ups.

**Files changed (high level)**

- [RegisterAttendance.tsx]
- [ViewAttendance.tsx]
- [InternalUsers.tsx]
- [App.tsx]
- [style.css]
- [PageTransition.tsx]

@santi4914 